### PR TITLE
Drop Ruby 1.9 and JRuby from supported platforms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,10 @@ rvm:
   - 2.2
   - 2.1
   - 2.0
-  - 1.9.3
-  - jruby-1.7.12
 
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 1.9.3
-    - rvm: jruby-1.7.12
   fast_finish: true
 
 # whitelist


### PR DESCRIPTION
Ruby 1.9 and JRuby have been unsupported in main Cucumber `cucumber-ruby`.
See also https://github.com/cucumber/cucumber-ruby-wire/commit/77d1f70b7c2576aeda15dd9dc06773c897290625#commitcomment-21260194
