### PR TITLE
Don't restrict Travis to master and prevent notifying cuke-devs about private forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,7 @@ matrix:
     - rvm: ruby-head
   fast_finish: true
 
-# whitelist
-branches:
-  only:
-    - master
-
 notifications:
-  email:
-    - cukes-devs@googlegroups.com
   webhooks:
     urls: # gitter
       - https://webhooks.gitter.im/e/dc010332f9d40fcc21c4


### PR DESCRIPTION
Removing the restriction of building master only seems only sensible: there's no other branch, so no point in restricting what gets build. This currently prevents people with their own fork from getting builds on Travis _unless_ they change this part in Travis configuration, and then try not to submit that in a PR.

Removing the cukes-dev notification is because this will only result in spamming the cukes-dev list with every built done on a private fork, for no good reason at all. The default notification targets (committer and commit author) are good enough ( https://docs.travis-ci.com/user/notifications#Default-notification-settings ).