### PR TITLE
Adapt to the move of Location to Cucumber::Core::Test

### DIFF
--- a/lib/cucumber/wire/add_hooks_filter.rb
+++ b/lib/cucumber/wire/add_hooks_filter.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Cucumber
   module Wire
     class AddHooksFilter < Core::Filter.new(:connections)
@@ -10,13 +11,13 @@ module Cucumber
       def before_hook(test_case)
         # TODO: is this dependency on Cucumber::Hooks OK? Feels a bit internal..
         # TODO: how do we express the location of the hook? Should we create one hook per connection so we can use the host:port of the connection?
-        Cucumber::Hooks.before_hook(test_case.source, Core::Ast::Location.new('TODO:wire')) do
+        Cucumber::Hooks.before_hook(Core::Test::Location.new('TODO:wire')) do
           connections.begin_scenario(test_case)
         end
       end
 
       def after_hook(test_case)
-        Cucumber::Hooks.after_hook(test_case.source, Core::Ast::Location.new('TODO:wire')) do
+        Cucumber::Hooks.after_hook(Core::Test::Location.new('TODO:wire')) do
           connections.end_scenario(test_case)
         end
       end

--- a/lib/cucumber/wire/protocol/requests.rb
+++ b/lib/cucumber/wire/protocol/requests.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'cucumber/wire/request_handler'
 require 'cucumber/step_argument'
 
@@ -69,7 +70,7 @@ module Cucumber
 
           def handle_diff!(tables)
             # TODO: figure out if / how we could get a location for a table from the wire (or make a null location)
-            location = Core::Ast::Location.new(__FILE__, __LINE__)
+            location = Core::Test::Location.new(__FILE__, __LINE__)
             table1 = table(tables[0], location)
             table2 = table(tables[1], location)
             table1.diff!(table2)
@@ -89,7 +90,7 @@ module Cucumber
           private
 
           def table(data, location)
-            Cucumber::MultilineArgument.from_core(Core::Ast::DataTable.new(data, location))
+            Cucumber::MultilineArgument.from_core(Core::Test::DataTable.new(data, location))
           end
         end
 

--- a/lib/cucumber/wire/step_definition.rb
+++ b/lib/cucumber/wire/step_definition.rb
@@ -1,4 +1,4 @@
-require 'cucumber/core/ast/location'
+require 'cucumber/core/test/location'
 
 module Cucumber
   module Wire
@@ -9,7 +9,7 @@ module Cucumber
         @connection = connection
         @id              = data['id']
         @regexp_source   = data['regexp'] || "Unknown"
-        @location        = Core::Ast::Location.from_file_colon_line(data['source'] || "unknown:0")
+        @location        = Core::Test::Location.from_file_colon_line(data['source'] || "unknown:0")
       end
 
       def invoke(args)


### PR DESCRIPTION
As consequences of the changes in cucumber/cucumber-ruby-core#156:
* the references to the `Location` class have to be updated (changed from `Cucumber::Core::Ast::Location` to `Cucumber::Core::Test::Location`).
* the `source` parameter has to be removed when creating `Hooks`. 