### PR TITLE
CI: Use JRuby 9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 
 matrix:
   include:
@@ -8,11 +7,11 @@ matrix:
     - rvm: 2.5
     - rvm: 2.4
     - rvm: 2.3
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       env: JRUBY_OPTS="--debug" LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
 
   fast_finish: true
 


### PR DESCRIPTION

This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)

  - remove the `sudo: false` directive, which is now unused - see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration