### PR TITLE
Use IdGenerator::UUID 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ end
 if ENV['CUCUMBER_RUBY']
   gem 'cucumber', path: ENV['CUCUMBER_RUBY']
 elsif !ENV['CUCUMBER_USE_RELEASED_GEMS']
-  gem 'cucumber', github: 'cucumber/cucumber-ruby', branch: 'fix-cucumber-wire-failing-tests'
+  gem 'cucumber', github: 'cucumber/cucumber-ruby'
 end
 

--- a/lib/cucumber/wire/add_hooks_filter.rb
+++ b/lib/cucumber/wire/add_hooks_filter.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+require 'cucumber/messages'
+
 module Cucumber
   module Wire
     class AddHooksFilter < Core::Filter.new(:connections)
@@ -11,15 +13,19 @@ module Cucumber
       def before_hook(test_case)
         # TODO: is this dependency on Cucumber::Hooks OK? Feels a bit internal..
         # TODO: how do we express the location of the hook? Should we create one hook per connection so we can use the host:port of the connection?
-        Cucumber::Hooks.before_hook('TODO:wire-hook-id', Core::Test::Location.new('TODO:wire')) do
+        Cucumber::Hooks.before_hook(id_generator.new_id, Core::Test::Location.new('TODO:wire')) do
           connections.begin_scenario(test_case)
         end
       end
 
       def after_hook(test_case)
-        Cucumber::Hooks.after_hook('TODO:wire-hook-id', Core::Test::Location.new('TODO:wire')) do
+        Cucumber::Hooks.after_hook(id_generator.new_id, Core::Test::Location.new('TODO:wire')) do
           connections.end_scenario(test_case)
         end
+      end
+
+      def id_generator
+        @id_generator ||= Cucumber::Messages::IdGenerator::UUID.new
       end
     end
   end

--- a/lib/cucumber/wire/protocol/requests.rb
+++ b/lib/cucumber/wire/protocol/requests.rb
@@ -69,10 +69,8 @@ module Cucumber
           end
 
           def handle_diff!(tables)
-            # TODO: figure out if / how we could get a location for a table from the wire (or make a null location)
-            location = Core::Test::Location.new(__FILE__, __LINE__)
-            table1 = table(tables[0], location)
-            table2 = table(tables[1], location)
+            table1 = table(tables[0])
+            table2 = table(tables[1])
             table1.diff!(table2)
           end
 
@@ -89,8 +87,8 @@ module Cucumber
 
           private
 
-          def table(data, location)
-            Cucumber::MultilineArgument.from_core(Core::Test::DataTable.new(data, location))
+          def table(data)
+            Cucumber::MultilineArgument.from_core(Core::Test::DataTable.new(data))
           end
         end
 


### PR DESCRIPTION
## Summary

Original idea behind CCK was to have predictable ids for comparing messages, but the way we compare messages in CCK (using `json-formatter`) makes this useless finally.

See [cucumber-ruby-core#195](https://github.com/cucumber/cucumber-ruby-core/pull/195) and [cucumber-ruby#1390](https://github.com/cucumber/cucumber-ruby/pull/1390)