### PR TITLE
Remove references to MultiJSON

### DIFF
--- a/features/support/fake_wire_server.rb
+++ b/features/support/fake_wire_server.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'json'
 require 'socket'
 
 class FakeWireServer
@@ -52,7 +52,7 @@ class FakeWireServer
     def handle(data)
       if protocol_entry = response_to(data.strip)
         sleep delay(data)
-        @on_message.call(MultiJson.load(protocol_entry['request'])[0])
+        @on_message.call(JSON.parse(protocol_entry['request'])[0])
         send_response(protocol_entry['response'])
       else
         serialized_exception = { :message => "Not understood: #{data}", :backtrace => [] }
@@ -64,7 +64,7 @@ class FakeWireServer
 
     def response_to(data)
       @protocol.detect do |entry|
-        MultiJson.load(entry['request']) == MultiJson.load(data)
+        JSON.parse(entry['request']) == JSON.parse(data)
       end
     end
 
@@ -73,7 +73,7 @@ class FakeWireServer
     end
 
     def delay(data)
-      message = MultiJson.load(data.strip)[0]
+      message = JSON.parse(data.strip)[0]
       @delays[message.to_sym] || 0
     end
   end

--- a/lib/cucumber/wire/connections.rb
+++ b/lib/cucumber/wire/connections.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'json'
 require 'socket'
 require 'cucumber/wire/connection'
 require 'cucumber/wire/configuration'

--- a/lib/cucumber/wire/data_packet.rb
+++ b/lib/cucumber/wire/data_packet.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'json'
 
 module Cucumber
   module Wire
@@ -7,7 +7,7 @@ module Cucumber
     class DataPacket
       class << self
         def parse(raw)
-          attributes = MultiJson.load(raw.strip)
+          attributes = JSON.parse(raw.strip)
           message = attributes[0]
           params  = attributes[1]
           new(message, params)
@@ -23,7 +23,7 @@ module Cucumber
       def to_json
         packet = [@message]
         packet << @params if @params
-        MultiJson.dump(packet)
+        JSON.generate(packet)
       end
 
       def handle_with(handler)


### PR DESCRIPTION
Related to [cucumber-ruby#1370](https://github.com/cucumber/cucumber-ruby/pull/1370)

Building naiver JSON gems fail on Windows and there's (since Ruby 2.0) a native build-in JSON gem, so let's use that instead.