### PR TITLE
Add release workflow for automating releases of the gem

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -86,4 +86,5 @@ jobs:
             --base release/v${{ env.next_version }} \
             --head pre-release/v${{ env.next_version }} \
             --title "Release v${{ env.next_version }}" \
-            --body-file ${{ runner.temp }}/body
+            --body-file ${{ runner.temp }}/body \
+            --reviewer @cucumber/cucumber-ruby

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,18 +13,18 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v2
-      - name: Parse version to be released from branch name
-        id: version-being-released
-        run: |
-          ref="${{ github.ref }}"
-          branch=${ref/refs\/heads\//}
-          version=${branch/release\/v/}
-          echo "::set-output name=result::$version"
+      - name: Read version to release from the changelog
+        id: next-release
+        uses: cucumber-actions/changelog-action@v1.3
+        with:
+          args: latest
+      - name: Set version environment variable
+        run: echo "version"=${{ steps.next-release.outputs.result }} > $GITHUB_ENV
       - name: read latest version from the changelog
         id: release-notes
         uses: mattwynne/changelog-action@v1.3
         with:
-          args: show ${{ steps.version-being-released.outputs.result }}
+          args: show ${{ env.version }}
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
           EOT
           gh release create \
             --notes-file ${{ runner.temp }}/notes \
-            v${{ steps.version-being-released.outputs.result }}
+            v${{ env.version }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
@@ -42,4 +42,4 @@ jobs:
       - name: Release to Rubygems
         run: |
           bundle exec gem build
-          bundle exec gem push cucumber-wire-${{ steps.version-being-release.outputs.result }}.gem -k ${{ env.CUKEBOT_GITHUB_TOKEN }}
+          bundle exec gem push cucumber-wire-${{ env.version }}.gem -k ${{ env.CUKEBOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - release/*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: Release
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Parse version to be released from branch name
+        id: version-being-released
+        run: |
+          ref="${{ github.ref }}"
+          branch=${ref/refs\/heads\//}
+          version=${branch/release\/v/}
+          echo "::set-output name=result::$version"
+      - name: read latest version from the changelog
+        id: release-notes
+        uses: mattwynne/changelog-action@v1.3
+        with:
+          args: show ${{ steps.version-being-released.outputs.result }}
+      - name: Create release
+        run: |
+          cat >${{ runner.temp }}/notes <<EOT
+          ${{ steps.release-notes.outputs.result }}
+          EOT
+          gh release create \
+            --notes-file ${{ runner.temp }}/notes \
+            v${{ steps.version-being-released.outputs.result }}
+      - name: Release to Rubygems
+        uses: cadwallion/publish-rubygems-action@master
+        env:
+          GITHUB_TOKEN: ${{secrets.CUKEBOT_GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,11 @@ jobs:
           gh release create \
             --notes-file ${{ runner.temp }}/notes \
             v${{ steps.version-being-released.outputs.result }}
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
       - name: Release to Rubygems
-        uses: cadwallion/publish-rubygems-action@master
-        env:
-          GITHUB_TOKEN: ${{secrets.CUKEBOT_GITHUB_TOKEN}}
-          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+        run: |
+          bundle exec gem build
+          bundle exec gem push cucumber-wire-${{ steps.version-being-release.outputs.result }}.gem -k ${{ env.CUKEBOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: Release
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
     steps:
@@ -28,6 +26,8 @@ jobs:
         with:
           args: show ${{ steps.version-being-released.outputs.result }}
       - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat >${{ runner.temp }}/notes <<EOT
           ${{ steps.release-notes.outputs.result }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,8 @@ jobs:
           ruby-version: 2.6
           bundler-cache: true
       - name: Release to Rubygems
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
           bundle exec gem build
-          bundle exec gem push cucumber-wire-${{ env.version }}.gem -k ${{ env.CUKEBOT_GITHUB_TOKEN }}
+          bundle exec gem push cucumber-wire-${{ env.version }}.gem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,5 +9,11 @@ Release Process
 
 ```
 git commit -am "Release X.Y.Z"
-make release
+git push
 ```
+
+This will trigger the [`pre-release`](.github/workflows/pre-release.yml) workflow which creates a PR
+to a `release/*` branch.
+
+Once a member of the [@cucumber/cucumber-ruby](https://github.com/orgs/cucumber/teams/cucumber-ruby) core team has approved the release by merging the PR, the new version of the gem will be released automatically
+by the [`release`](.github/workflows/release.yml) workflow.


### PR DESCRIPTION
I've added a `Release` environment with the `RUBYGEMS_API` secret in it needed by this workflow. Access to run workflows in that environment is restricted to members of the @cucumber/cucumber-ruby team. Effectively, that means they are the only people who can make releases, and the only people who could leak this secret.

I generated a new API token in rubygems specifically for this repo, and copied it directly into GitHub, so there is no copy of that secret anywhere else.

<img width="951" alt="Screenshot 2021-08-05 at 1 25 16 PM" src="https://user-images.githubusercontent.com/19260/128416328-c6a18f18-42a6-4579-9cef-8fe53aca3c17.png">

~~The CUKEBOT_GITHUB_TOKEN (needed by the Rubygems rake release task to push the new tag) is a copy of the one from Keybase.~~
