### PR TITLE
CI: Refer to cucumber-actions/ Action after a repo rename

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         run: echo "version"=${{ steps.next-release.outputs.result }} > $GITHUB_ENV
       - name: read latest version from the changelog
         id: release-notes
-        uses: mattwynne/changelog-action@v1.3
+        uses: cucumber-actions/changelog-action@v1.3
         with:
           args: show ${{ env.version }}
       - name: Create release


### PR DESCRIPTION
Make the CI config one step more uniform after a rename.

# Description

Use `cucumber-actions/` as the "repo" for the used GitHub Action.

# Motivation & context

I learned that the repo had been transferred from the mattwynne/ prefix to the cucumber-actions/ one.

This change makes the usage uniform in this YAML file.

I expect them to refer to the same code.



## Type of change

- Refactoring/debt (improvement to code design or tooling without changing behaviour)

- [ ] add CHANGELOG.md note


# Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
