### PR TITLE
Final iterations on release script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,18 @@ jobs:
           args: latest
       - name: Set version environment variable
         run: echo "version"=${{ steps.next-release.outputs.result }} > $GITHUB_ENV
-      - name: read latest version from the changelog
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.2
+          bundler-cache: true
+      - run: |
+          bundle exec gem build cucumber-wire.gemspec
+      - name: Release to Rubygems
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          bundle exec gem push cucumber-wire-${{ env.version }}.gem
+      - name: read release notes from the changelog
         id: release-notes
         uses: mattwynne/changelog-action@v1.3
         with:
@@ -33,14 +44,5 @@ jobs:
           EOT
           gh release create \
             --notes-file ${{ runner.temp }}/notes \
+            --title v${{ env.version }} \
             v${{ env.version }}
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.6
-          bundler-cache: true
-      - name: Release to Rubygems
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: |
-          bundle exec gem build
-          bundle exec gem push cucumber-wire-${{ env.version }}.gem


### PR DESCRIPTION
- Release v6.1.0 (#48)
- See if this helps the release workflow to trigger
- Separate gem build and gem push
- Create GitHub Release after gem push has succeeded
- Use a newer Ruby
- Create title for GH Release
