### PR TITLE
Make wire compatible with html formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+- Fix usage with message-related formatters like the html formatter
+  ([PR#57](https://github.com/cucumber/cucumber-ruby-wire/pull/57)
+   [Issue#56](https://github.com/cucumber/cucumber-ruby-wire/issues/56))
+
+- Removed dependency to cucumber-messages
+
 ### Removed
 
 ## [6.2.0]

--- a/cucumber-wire.gemspec
+++ b/cucumber-wire.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'cucumber-core', '~> 10.1', '>= 10.1.0'
   s.add_dependency 'cucumber-cucumber-expressions', '~> 14.0', '>= 14.0.0'
-  s.add_dependency 'cucumber-messages', '~> 17.1', '>= 17.1.1'
 
   s.add_development_dependency 'aruba', '~> 2.0', '>= 2.0.0'
   s.add_development_dependency 'cucumber', '~> 7.0', '>= 7.0.0'

--- a/features/step_matches_message.feature
+++ b/features/step_matches_message.feature
@@ -81,3 +81,18 @@ Feature: Step matches message
 
       """
     And the stderr should not contain anything
+
+  Scenario: Step matches initialize step definitions compatible with html formatter
+
+    Given there is a wire server running on port 54321 which understands the following protocol:
+      | request                                              | response                                                                           |
+      | ["step_matches",{"name_to_match":"we're all wired"}] | ["success",[{"id":"1", "args":[], "source":"MyApp.MyClass:123", "regexp":"we.*"}]] |
+    When I run `cucumber --format html --publish-quiet`
+    Then it should pass with:
+      """
+
+      1 scenario (1 skipped)
+      1 step (1 skipped)
+
+      """
+    And the stderr should not contain anything

--- a/features/step_matches_message.feature
+++ b/features/step_matches_message.feature
@@ -87,12 +87,15 @@ Feature: Step matches message
     Given there is a wire server running on port 54321 which understands the following protocol:
       | request                                              | response                                                                           |
       | ["step_matches",{"name_to_match":"we're all wired"}] | ["success",[{"id":"1", "args":[], "source":"MyApp.MyClass:123", "regexp":"we.*"}]] |
-    When I run `cucumber --format html --publish-quiet`
+      | ["begin_scenario"]                                   | ["success"]                                                                        |
+      | ["invoke",{"id":"1","args":[]}]                      | ["success"]                                                                        |
+      | ["end_scenario"]                                     | ["success"]                                                                        |
+    When I run `cucumber --format message --out messages.json --publish-quiet`
     Then it should pass with:
       """
 
-      1 scenario (1 skipped)
-      1 step (1 skipped)
+      1 scenario (1 passed)
+      1 step (1 passed)
 
       """
     And the stderr should not contain anything

--- a/features/step_matches_message.feature
+++ b/features/step_matches_message.feature
@@ -99,3 +99,7 @@ Feature: Step matches message
 
       """
     And the stderr should not contain anything
+    And the file "messages.json" should contain:
+      """
+      {"testRunFinished":{"success":false
+      """

--- a/lib/cucumber/wire/add_hooks_filter.rb
+++ b/lib/cucumber/wire/add_hooks_filter.rb
@@ -13,12 +13,10 @@ module Cucumber
         # TODO: is this dependency on Cucumber::Hooks OK? Feels a bit internal..
         # TODO: how do we express the location of the hook? Should we create one hook per connection so we can use the host:port of the connection?
 
-        hook = Cucumber::Glue::Hook.new(id_generator.new_id, Cucumber::Hooks::BeforeHook, [], ->(test_case) { connections.begin_scenario(test_case) })
-        action = ->(result) { hook.invoke('Before', test_case.with_result(result)) }
+        hook = instanciate_wire_hook(:begin_scenario)
+        action = ->(result) { hook.invoke('Before', [Cucumber::RunningTestCase.new(test_case).with_result(result), connections]) }
 
-        hook_step = Cucumber::Hooks.before_hook(id_generator.new_id, Core::Test::Location.new('TODO:wire')) do
-          connections.begin_scenario(test_case)
-        end
+        hook_step = Cucumber::Hooks.before_hook(id_generator.new_id, Core::Test::Location.new('wire'), &action)
 
         configuration.event_bus.hook_test_step_created(hook_step, hook)
 
@@ -26,12 +24,10 @@ module Cucumber
       end
 
       def after_hook(test_case)
-        hook = Cucumber::Glue::Hook.new(id_generator.new_id, Cucumber::Hooks::AfterHook, [], ->(test_case) { connections.end_scenario(test_case) })
-        action = ->(result) { hook.invoke('After', test_case.with_result(result)) }
+        hook = instanciate_wire_hook(:end_scenario)
+        action = ->(result) { hook.invoke('After', [Cucumber::RunningTestCase.new(test_case).with_result(result), connections]) }
 
-        hook_step = Cucumber::Hooks.after_hook(id_generator.new_id, Core::Test::Location.new('TODO:wire')) do
-          connections.end_scenario(test_case)
-        end
+        hook_step = Cucumber::Hooks.after_hook(id_generator.new_id, Core::Test::Location.new('wire'), &action)
 
         configuration.event_bus.hook_test_step_created(hook_step, hook)
 
@@ -44,6 +40,17 @@ module Cucumber
 
       def configuration
         @configuration ||= connections.configuration
+      end
+
+      private
+
+      def instanciate_wire_hook(hook_method)
+        Cucumber::Glue::Hook.new(
+          id_generator.new_id,
+          connections.registry,
+          [],
+          ->(test_case, connections) { connections.send(hook_method, test_case) }
+        )
       end
     end
   end

--- a/lib/cucumber/wire/connections.rb
+++ b/lib/cucumber/wire/connections.rb
@@ -13,7 +13,7 @@ module Cucumber
   module Wire
 
     class Connections
-      attr_reader :connections
+      attr_reader :connections, :configuration
       private :connections
 
       def initialize(connections, configuration, registry)
@@ -45,7 +45,6 @@ module Cucumber
       def snippets(code_keyword, step_name, multiline_arg_class_name)
         connections.map { |c| c.snippet_text(code_keyword, step_name, multiline_arg_class_name) }.flatten
       end
-
     end
   end
 end

--- a/lib/cucumber/wire/connections.rb
+++ b/lib/cucumber/wire/connections.rb
@@ -13,7 +13,7 @@ module Cucumber
   module Wire
 
     class Connections
-      attr_reader :connections, :configuration
+      attr_reader :connections, :configuration, :registry
       private :connections
 
       def initialize(connections, configuration, registry)

--- a/lib/cucumber/wire/step_definition.rb
+++ b/lib/cucumber/wire/step_definition.rb
@@ -3,7 +3,7 @@ require 'cucumber/core/test/location'
 module Cucumber
   module Wire
     class StepDefinition
-      attr_reader :regexp_source, :location, :registry, :expression
+      attr_reader :id, :regexp_source, :location, :registry, :expression
 
       def initialize(connection, data, registry)
         @connection = connection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes #56 

It seems that the wire protocol is not compatible with the html formatter. 

## Note to other contributors

Tests seems to be failing due to the usage of hooks in the wire plugin and how they are managed by new formatters using messages.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
