### PR TITLE
Fix #56 crash with wire protocol while output format is html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+- Fix usage with message-related formatters like the html formatter especial for steps with arguments
+  ([PR#65](https://github.com/cucumber/cucumber-ruby-wire/pull/65)
+   [Issue#56](https://github.com/cucumber/cucumber-ruby-wire/issues/56))
+
 ### Removed
 
 ## [6.2.1]

--- a/features/step_matches_message.feature
+++ b/features/step_matches_message.feature
@@ -86,9 +86,9 @@ Feature: Step matches message
 
     Given there is a wire server running on port 54321 which understands the following protocol:
       | request                                              | response                                                                           |
-      | ["step_matches",{"name_to_match":"we're all wired"}] | ["success",[{"id":"1", "args":[], "source":"MyApp.MyClass:123", "regexp":"we.*"}]] |
+      | ["step_matches",{"name_to_match":"we're all wired"}] | ["success",[{"id":"1", "args":[{"pos": 11, "val": "wired"}], "source":"MyApp.MyClass:123", "regexp":"we're all (.*)"}]] |
       | ["begin_scenario"]                                   | ["success"]                                                                        |
-      | ["invoke",{"id":"1","args":[]}]                      | ["success"]                                                                        |
+      | ["invoke",{"id":"1","args":["wired"]}]               | ["success"]                                                                        |
       | ["end_scenario"]                                     | ["success"]                                                                        |
     When I run `cucumber --format message --out messages.json --publish-quiet`
     Then it should pass with:

--- a/lib/cucumber/wire/step_argument.rb
+++ b/lib/cucumber/wire/step_argument.rb
@@ -19,6 +19,18 @@ module Cucumber
       def group
         CucumberExpressions::Group.new(@value, @offset, @offset + @value.length, [])
       end
+
+      def parameter_type
+        # `Cucumber::Formatter::MessageBuilder` treats parameter_type as **required**
+        # when building `Cucumber::Messages::StepMatchArgument` with `parameter_type_name` in method `step_match_arguments`,
+        # though `parameterTypeName` of `StepMatchArgument` is not **required** according to
+        # https://github.com/cucumber/messages/blob/main/messages.md#stepmatchargument
+        # Here is workaround for this
+        Class.new do
+          def name
+          end
+        end.new
+      end
     end
   end
 end


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Fixes crash while cucumber output format is html

### ⚡️ What's your motivation? 

Fixes #56

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

`Cucumber::Formatter::MessageBuilder` treats parameter_type as **required** when building `Cucumber::Messages::StepMatchArgument` with `parameter_type_name` in method `step_match_arguments`, though `parameterTypeName` of `StepMatchArgument` is not **required** according to [StepMatchArgument](https://github.com/cucumber/messages/blob/main/messages.md#stepmatchargument).

What I argue are:
- Cucumber::Formatter::MessageBuilder **should not** assumed `argument` responds to method `parameter_type`, which could be a defect in cucumber-ruby? Code is [here](https://github.com/cucumber/cucumber-ruby/blob/8e519a5cc571e2910e27ce280551d0cdcfc06fab/lib/cucumber/formatter/message_builder.rb#L134C9-L134C9)
- I guess `parameterTypeName` comes from [cucumber-expressions](https://github.com/cucumber/cucumber-expressions#parameter-types), as a Wire protocol plugin, it cannot offer parameterTypeName directly, it should be offered by the backend wire server, but, not all of backend language implementation would be considering adopting cucumber-expressions? Maybe we can expand wire protocol to provide a facilitation to support parameter_type in future, but we'd better get it just work now.

Point it out if I'm wrong, very appreciate.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
