### PR TITLE
Support quote in backtrace for Ruby 3.4

### DIFF
--- a/features/handle_unexpected_response.feature
+++ b/features/handle_unexpected_response.feature
@@ -25,7 +25,7 @@ Feature: Handle unexpected response
       | ["begin_scenario"]                                   | ["yikes"]                           |
       | ["step_matches",{"name_to_match":"we're all wired"}] | ["success",[{"id":"1", "args":[]}]] |
     When I run `cucumber -f pretty`
-    Then the output should contain:
+    Then the output should match:
       """
-      undefined method `handle_yikes'
+      undefined method [`']handle_yikes'
       """


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/16495

This is needed for Ruby 3.4, unless Cucumber can fix this somehow differently:

https://github.com/cucumber/cucumber-ruby/pull/1771#issuecomment-2569128470